### PR TITLE
Attempt to use vatsim login from first xRadar connection

### DIFF
--- a/src/xatis/util.clj
+++ b/src/xatis/util.clj
@@ -1,6 +1,8 @@
 (ns ^{:author "Daniel Leong"
       :doc "Utils"}
-  xatis.util)
+  xatis.util
+  (:require [clojure.java.io :refer [file]]))
+            
 
 (def atis-text-max-width 64)
 
@@ -31,6 +33,16 @@
 ;;
 ;; Public utils
 ;;
+
+(defn resolve-file
+  [path]
+  (when path
+    (let [home (System/getProperty "user.home")]
+      (-> path
+          (.replace "~" home)
+          (.replace "$HOME" home)
+          (.replace "%USERPROFILE%" home)
+          file))))
 
 (defn re-replace
   "Functional regex processing. `pred` will be called


### PR DESCRIPTION
Closes #9

Uses the default settings file only. May be beneficial to
pull out the profile reading functionality from xRadar into
a separate lib; in the future, it may make sense to incorporate
xAtis into xRadar, so depending on xRadar now could prove
annoying in the future

Note that we assume all xRadar connections would share a vatsim ID; given that you're only allowed one, this seems a fair assumption.
